### PR TITLE
[6.0]: Add major version roll forward if the using application targets .NET 7+.

### DIFF
--- a/pkg/sfx/runtimeconfig.json
+++ b/pkg/sfx/runtimeconfig.json
@@ -1,6 +1,7 @@
 {
   "runtimeOptions": {
     "tfm": "net6.0",
+    "rollForward": "Major",
     "frameworks": [
       {
         "name": "Microsoft.AspNetCore.App",


### PR DESCRIPTION
Cherry Pick of #29.